### PR TITLE
Fix port in http headers

### DIFF
--- a/templates/template.j2
+++ b/templates/template.j2
@@ -14,7 +14,7 @@ frontend HTTP
 
 {{ range $cert, $details := .SniList }}
 {{- range $dummyidx, $domain := $details.Domains }}
-    acl      acl-http-{{ $domain }} hdr(host) -i {{ $domain }}
+    acl      acl-http-{{ $domain }} hdr(host) -i ^{{ replace $domain "." "\\." }}(:80)?$
     use_backend backend-{{ index $.HostToBackend $domain }}-http1 if acl-http-{{ $domain }}
 {{- end }}
 {{- end }}

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -69,7 +69,7 @@ frontend wrap-frontend-https
 
 {{ range $cert, $details := .SniList }}
 {{- range $dummyidx, $domain := $details.Domains }}
-    acl      acl-https-{{ $domain }} hdr(host) -i {{ $domain }}
+    acl      acl-https-{{ $domain }} hdr_reg(host) -i ^{{ replace $domain "." "\\." }}(:443)?$
     use_backend backend-{{ index $.HostToBackend $domain }}-http1 if acl-https-{{ $domain }} !{ ssl_fc_alpn -i h2 }
     use_backend backend-{{ index $.HostToBackend $domain }}-http2 if acl-https-{{ $domain }} { ssl_fc_alpn -i h2 }
 {{ end }}


### PR DESCRIPTION
Also route requests in which the HTTP `Host` header contains a port ([see here for more info](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23).