### PR TITLE
Allow configuring multiple clusters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,14 @@
 ---
 k8router_master_group: kube-master
+k8router_clusters:
+  - name: cluster
+    apiserver_hostname:
+      - "{{ kubernetes_ha_domain_intern }}"
+    apiserver_cert: ""
+    apiserver_key: ""
+    apiserver_ca: ""
+    apiserver_pem: ""
+
 k8router_apiserver_hostname:
   - "{{ kubernetes_ha_domain_intern }}"
 k8router_apiserver_cert: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,18 +1,11 @@
 ---
-k8router_master_group: kube-master
+
 k8router_clusters:
   - name: cluster
     apiserver_hostname:
       - "{{ kubernetes_ha_domain_intern }}"
-    apiserver_cert: ""
-    apiserver_key: ""
-    apiserver_ca: ""
-    apiserver_pem: ""
+    apiserver_cert: "{{ k8router_apiserver_cert }}"
+    apiserver_key: "{{ k8router_apiserver_key }}"
+    apiserver_pem: "{{ k8router_apiserver_pem }}"
 
-k8router_apiserver_hostname:
-  - "{{ kubernetes_ha_domain_intern }}"
-k8router_apiserver_cert: ""
-k8router_apiserver_key: ""
-k8router_apiserver_ca: ""
-k8router_apiserver_pem: "{{ k8router_apiserver_cert }}.pem"
 k8router_config: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
     become: True
     changed_when: False
     shell: cat {{ item.apiserver_cert }} {{ item.apiserver_key }} > {{ item.apiserver_pem }}
-    with_items: k8router_clusters
+    with_items: "{{ k8router_clusters }}"
 
   - name: Flush handlers
     meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,10 +18,11 @@
       - config.yml
     notify: restart k8router
 
-  - name: Assemble certificate
+  - name: Assemble certificates for clusters
     become: True
     changed_when: False
-    shell: cat {{ k8router_apiserver_cert }} {{ k8router_apiserver_key }} > {{ k8router_apiserver_pem }}
+    shell: cat {{ item.apiserver_cert }} {{ item.apiserver_key }} > {{ item.apiserver_pem }}
+    with_items: k8router_clusters
 
   - name: Flush handlers
     meta: flush_handlers

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -47,6 +47,9 @@ frontend HTTPS
     # We also need to pass through the old kubernetes API (or deployment wont work)
     acl      acl-k8s-tectonic-api req_ssl_sni -i -m str kube-api.vis.ethz.ch
     use_backend K8S if acl-k8s-tectonic-api
+    # ...and the Tectonic backend as it hardcodes the CA in it's kubeconfig
+    acl      acl-k8s-tectonic req_ssl_sni -i -m str kube.vis.ethz.ch
+    use_backend TConsole if acl-k8s-tectonic
     # No tectonic here - moved _behind_ the decrypt!
     default_backend wrap-backend-https
 

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -21,8 +21,6 @@ frontend HTTP
     acl      acl-rgw hdr(host) -i rgw.vis.ethz.ch
     use_backend rgw if acl-rgw
 
-    default_backend tectonic-bridge-http
-
 {% endraw %}
 {# Preliminary HTTPS handler - needed to split out the kubernetes API
    as it uses client certificates #}
@@ -44,22 +42,7 @@ frontend HTTPS
 {% endfor %}
 {% endfor %}
 {% raw %}
-    # We also need to pass through the old kubernetes API (or deployment wont work)
-    acl      acl-k8s-tectonic-api req_ssl_sni -i -m str kube-api.vis.ethz.ch
-    use_backend K8S if acl-k8s-tectonic-api
-    # ...and the Tectonic backend as it hardcodes the CA in it's kubeconfig
-    acl      acl-k8s-tectonic req_ssl_sni -i -m str kube.vis.ethz.ch
-    use_backend TConsole if acl-k8s-tectonic
-    # No tectonic here - moved _behind_ the decrypt!
     default_backend wrap-backend-https
-
-backend tectonic-bridge-http
-    mode http
-    server loopback 127.0.0.1:10920 send-proxy-v2
-
-backend tectonic-bridge-https
-    mode http
-    server loopback 127.0.0.1:10921 send-proxy-v2 ssl verify none
 
 {% endraw %}
 {# Main HTTPS handler #}

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -18,6 +18,11 @@ frontend HTTP
     use_backend backend-{{ index $.HostToBackend $domain }}-http1 if acl-http-{{ $domain }}
 {{- end }}
 {{- end }}
+    acl      acl-regharbor hdr(host) -i registry.vis.ethz.ch
+    use_backend regharbor if acl-regharbor
+    acl      acl-rgw hdr(host) -i rgw.vis.ethz.ch
+    use_backend rgw if acl-rgw
+
     default_backend tectonic-bridge-http
 
 {% endraw %}
@@ -39,6 +44,9 @@ frontend HTTPS
     use_backend kube-apiserver if acl-k8s-apiserver-{{ loop.index }}
 {% endfor %}
 {% raw %}
+    # We also need to pass through the old kubernetes API (or deployment wont work)
+    acl      acl-k8s-tectonic-api req_ssl_sni -i -m str kube-api.vis.ethz.ch
+    use_backend K8S if acl-k8s-tectonic-api
     # No tectonic here - moved _behind_ the decrypt!
     default_backend wrap-backend-https
 
@@ -84,6 +92,10 @@ frontend wrap-frontend-https
     use_backend backend-{{ index $.HostToBackend $domain }}-http2 if acl-https-{{ $domain }} { ssl_fc_alpn -i h2 }
 {{ end }}
 {{- end }}
+    acl      acl-regharbor hdr(host) -i -m str registry.vis.ethz.ch
+    use_backend k8s-ssl-regharbor if acl-regharbor
+    acl      acl-rgw hdr(host) -i -m str rgw.vis.ethz.ch
+    use_backend k8s-ssl-rgw if acl-rgw
 
     default_backend tectonic-bridge-https
 
@@ -114,5 +126,22 @@ backend backend-{{ $backend }}-http2
     server   server-{{ $server.Name }} {{ $server.IP }}:81 check send-proxy proto h2
 {{- end }}
 {{- end }}
-
 {% endraw %}
+
+{# Legacy hosts, but in HTTP instead of TCP mode #}
+backend k8s-ssl-regharbor
+    balance source
+    hash-type consistent
+    stick-table type ip size 20k peers tcrouter_rep
+    stick on src
+    option httpchk GET / HTTP/1.1\r\nHost:\ registry.vis.ethz.ch
+    server   registry 10.233.42.80:444 send-proxy ssl sni str(registry.vis.ethz.ch) verify none check
+
+backend k8s-ssl-rgw
+    balance source
+    hash-type consistent
+    stick-table type ip size 20k peers tcrouter_rep
+    stick on src
+    option httpchk GET / HTTP/1.1\r\nHost:\ rgw.vis.ethz.ch
+    server   rgw-1 10.233.42.67:443  ssl sni str(rgw.vis.ethz.ch) verify none check
+    server   rgw-2 10.233.42.68:443  ssl sni str(rgw.vis.ethz.ch) verify none check

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -18,8 +18,6 @@ frontend HTTP
     use_backend backend-{{ index $.HostToBackend $domain }}-http1 if acl-http-{{ $domain }}
 {{- end }}
 {{- end }}
-    acl      acl-regharbor hdr(host) -i registry.vis.ethz.ch
-    use_backend regharbor if acl-regharbor
     acl      acl-rgw hdr(host) -i rgw.vis.ethz.ch
     use_backend rgw if acl-rgw
 
@@ -96,8 +94,6 @@ frontend wrap-frontend-https
     use_backend backend-{{ index $.HostToBackend $domain }}-http2 if acl-https-{{ $domain }} { ssl_fc_alpn -i h2 }
 {{ end }}
 {{- end }}
-    acl      acl-regharbor hdr(host) -i -m str registry.vis.ethz.ch
-    use_backend k8s-ssl-regharbor if acl-regharbor
     acl      acl-rgw hdr(host) -i -m str rgw.vis.ethz.ch
     use_backend k8s-ssl-rgw if acl-rgw
 
@@ -132,15 +128,7 @@ backend backend-{{ $backend }}-http2
 {{- end }}
 {% endraw %}
 
-{# Legacy hosts, but in HTTP instead of TCP mode #}
-backend k8s-ssl-regharbor
-    balance source
-    hash-type consistent
-    stick-table type ip size 20k peers tcrouter_rep
-    stick on src
-    option httpchk GET / HTTP/1.1\r\nHost:\ registry.vis.ethz.ch
-    server   registry 10.233.42.80:444 send-proxy ssl sni str(registry.vis.ethz.ch) verify none check
-
+{# Other hosts, but in HTTP instead of TCP mode #}
 backend k8s-ssl-rgw
     balance source
     hash-type consistent

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -4,12 +4,12 @@ frontend HTTP
 {{- range $dummyidx, $ip := .IPs }}
     bind     {{ $ip }}:80
 {{- end }}
-    reqadd X-Forwarded-Proto:\ http
-    reqadd X-Forwarded-Port:\ 80
+    http-request add-header X-Forwarded-Proto http
+    http-request add-header X-Forwarded-Port 80
     option forwardfor
     http-request add-header X-CLIENT-IP %[src]
 {% endraw %}
-    reqadd X-Kubernauts-Via:\ {{ ansible_fqdn }}
+    http-request add-header X-Kubernauts-Via {{ ansible_fqdn }}
 {% raw %}
 
 {{ range $cert, $details := .SniList }}
@@ -61,11 +61,11 @@ frontend wrap-frontend-https
     http-request set-header X-Kubernauts-TLSCipher %[ssl_fc_cipher]
     http-request set-header X-Kubernauts-TLS13Early %[ssl_fc_has_early]
     http-request add-header X-CLIENT-IP %[src]
-    reqadd X-Forwarded-Proto:\ https
-    reqadd X-Forwarded-Port:\ 443
+    http-request add-header X-Forwarded-Proto https
+    http-request add-header X-Forwarded-Port 443
     option forwardfor
 {% endraw %}
-    reqadd X-Kubernauts-Edge:\ {{ ansible_fqdn }}
+    http-request add-header X-Kubernauts-Edge {{ ansible_fqdn }}
 {% raw %}
 
     http-request deny if !METH_GET { ssl_fc_has_early }

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -47,8 +47,8 @@ backend tectonic-bridge-http
     server loopback 127.0.0.1:10920 send-proxy-v2
 
 backend tectonic-bridge-https
-    mode tcp
-    server loopback 127.0.0.1:10921 send-proxy-v2
+    mode http
+    server loopback 127.0.0.1:10921 send-proxy-v2 ssl verify none
 
 {% endraw %}
 {# Main HTTPS handler #}

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -18,6 +18,7 @@ frontend HTTP
     use_backend backend-{{ index $.HostToBackend $domain }}-http1 if acl-http-{{ $domain }}
 {{- end }}
 {{- end }}
+    default_backend tectonic-bridge-http
 
 frontend HTTPS
 {{- range $dummyidx, $ip := .IPs }}
@@ -41,8 +42,16 @@ frontend HTTPS
 {{- end }}
 {{- end }}
 {{ if ne .DefaultWildcardCert "" }}
-    default_backend wrap-backend-{{ .DefaultWildcardCert }}
+    default_backend tectonic-bridge-https
 {{- end }}
+
+backend tectonic-bridge-http
+    mode tcp
+    server loopback 127.0.0.1:10920 send-proxy-v2
+
+backend tectonic-bridge-https
+    mode tcp
+    server loopback 127.0.0.1:10921 send-proxy-v2
 
 {{ range $cert, $details := .SniList }}
 backend wrap-backend-{{ $cert }}

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -61,7 +61,7 @@ backend wrap-backend-{{ $cert }}
 frontend wrap-frontend-{{ $cert }}
     mode     http
     option http-use-htx
-    bind     127.0.0.1:{{ $details.LocalForwardPort }} crt {{ $details.Path }} ssl accept-proxy alpn h2,http/1.1 allow-0rtt
+    bind     127.0.0.1:{{ $details.LocalForwardPort }} crt {{ $details.Path }} ssl accept-proxy alpn h2,http/1.1
 
     http-request set-header X-Kubernauts-ALPN %[ssl_fc_alpn]
     http-request set-header X-Kubernauts-HTTP %[req.ver]
@@ -104,7 +104,7 @@ backend backend-{{ $backend }}-http2
     http-reuse never
 
 {{- range $dummyidx, $server := index $.BackendCombinationList $backend }}
-    server   server-{{ $server.Name }} {{ $server.IP }}:81 check send-proxy proto h2 allow-0rtt
+    server   server-{{ $server.Name }} {{ $server.IP }}:81 check send-proxy proto h2
 {{- end }}
 {{- end }}
 

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -46,7 +46,7 @@ frontend HTTPS
 {{- end }}
 
 backend tectonic-bridge-http
-    mode tcp
+    mode http
     server loopback 127.0.0.1:10920 send-proxy-v2
 
 backend tectonic-bridge-https

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -68,7 +68,8 @@ backend wrap-backend-https
 frontend wrap-frontend-https
     mode     http
     option http-use-htx
-    bind     127.0.0.1:12345 {{ range $cert, $details := .SniList }} crt {{ $details.Path }}{{ end }} ssl accept-proxy alpn h2,http/1.1 allow-0rtt
+    bind     127.0.0.1:12345 {{ range $cert, $details := .SniList }} crt {{ $details.Path }}{{ end }} ssl accept-proxy alpn h2,http/1.1
+    # Disabled for now: allow-0rtt
 
     http-request set-header X-Kubernauts-ALPN %[ssl_fc_alpn]
     http-request set-header X-Kubernauts-HTTP %[req.ver]

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -82,9 +82,6 @@ frontend wrap-frontend-https
     acl      acl-rgw hdr(host) -i -m str rgw.vis.ethz.ch
     use_backend k8s-ssl-rgw if acl-rgw
 
-    default_backend tectonic-bridge-https
-
-
 {% endraw %}
 {# Backends #}
 {% raw %}

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -110,12 +110,3 @@ backend backend-{{ $backend }}-http2
 {{- end }}
 {% endraw %}
 
-{# Other hosts, but in HTTP instead of TCP mode #}
-backend k8s-ssl-rgw
-    balance source
-    hash-type consistent
-    stick-table type ip size 20k peers tcrouter_rep
-    stick on src
-    option httpchk GET / HTTP/1.1\r\nHost:\ rgw.vis.ethz.ch
-    server   rgw-1 10.233.42.67:443  ssl sni str(rgw.vis.ethz.ch) verify none check
-    server   rgw-2 10.233.42.68:443  ssl sni str(rgw.vis.ethz.ch) verify none check

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -39,7 +39,7 @@ frontend HTTPS
 {% endraw %}
 {% for cluster in k8router_clusters %}
 {% for item in cluster.apiserver_hostname %}
-    acl      acl-k8s-apiserver-{{ item | replace('.', '-' }} req_ssl_sni -i -m str {{ item }}
+    acl      acl-k8s-apiserver-{{ item | replace('.', '-') }} req_ssl_sni -i -m str {{ item }}
     use_backend kube-apiserver-{{ cluster.name }} if acl-k8s-apiserver-{{ item | replace('.', '-') }}
 {% endfor %}
 {% endfor %}

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -37,9 +37,11 @@ frontend HTTPS
     tcp-request inspect-delay 5s
     tcp-request content accept if { req_ssl_hello_type 1 }
 {% endraw %}
-{% for item in k8router_apiserver_hostname %}
-    acl      acl-k8s-apiserver-{{ loop.index }} req_ssl_sni -i -m str {{ item }}
-    use_backend kube-apiserver if acl-k8s-apiserver-{{ loop.index }}
+{% for cluster in k8router_clusters %}
+{% for item in cluster.apiserver_hostname %}
+    acl      acl-k8s-apiserver-{{ item | replace('.', '-' }} req_ssl_sni -i -m str {{ item }}
+    use_backend kube-apiserver-{{ cluster.name }} if acl-k8s-apiserver-{{ item | replace('.', '-') }}
+{% endfor %}
 {% endfor %}
 {% raw %}
     # We also need to pass through the old kubernetes API (or deployment wont work)

--- a/templates/template.j2
+++ b/templates/template.j2
@@ -18,8 +18,6 @@ frontend HTTP
     use_backend backend-{{ index $.HostToBackend $domain }}-http1 if acl-http-{{ $domain }}
 {{- end }}
 {{- end }}
-    acl      acl-rgw hdr(host) -i rgw.vis.ethz.ch
-    use_backend rgw if acl-rgw
 
 {% endraw %}
 {# Preliminary HTTPS handler - needed to split out the kubernetes API
@@ -79,8 +77,6 @@ frontend wrap-frontend-https
     use_backend backend-{{ index $.HostToBackend $domain }}-http2 if acl-https-{{ $domain }} { ssl_fc_alpn -i h2 }
 {{ end }}
 {{- end }}
-    acl      acl-rgw hdr(host) -i -m str rgw.vis.ethz.ch
-    use_backend k8s-ssl-rgw if acl-rgw
 
 {% endraw %}
 {# Backends #}


### PR DESCRIPTION
This PR adds support to expose the API of multiple Kubernetes clusters.
I have also cleaned up unused variables and tried to keep it backwards compatible.